### PR TITLE
Integrate Sentry error logging

### DIFF
--- a/shared/utils/errorHandler.ts
+++ b/shared/utils/errorHandler.ts
@@ -50,7 +50,22 @@ export const logError = (error: unknown, context?: string) => {
   // Burada hata loglarını bir servise gönderebilir veya dosyaya yazabilirsiniz
   console.error('Error Log:', errorLog);
   
-  // TODO: Hata loglarını bir servise gönder (örn: Sentry, LogRocket vb.)
+  if (process.env.ENABLE_SENTRY === 'true') {
+    import('@sentry/node')
+      .then((Sentry) => {
+        if (!Sentry.getCurrentHub().getClient()) {
+          Sentry.init({ dsn: process.env.SENTRY_DSN });
+        }
+        if (error instanceof Error) {
+          Sentry.captureException(error);
+        } else {
+          Sentry.captureMessage(JSON.stringify(error));
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to send error to Sentry:', err);
+      });
+  }
 };
 
 export const createErrorHandler = (context: string) => {


### PR DESCRIPTION
## Summary
- enable optional logging service in `logError`
- forward errors to Sentry when `ENABLE_SENTRY` env var is `true`

## Testing
- `npm run build` *(fails: Cannot find module '@sentry/node')*

------
https://chatgpt.com/codex/tasks/task_e_684c4744abe8832ca28c0d3b42f7746e