### PR TITLE
Fix drizzle config in server

### DIFF
--- a/server/drizzle.config.ts
+++ b/server/drizzle.config.ts
@@ -9,5 +9,4 @@ export default {
   dbCredentials: {
     connectionString: process.env.DATABASE_URL!,
   },
-  dialect: 'postgresql',
 } satisfies Config; 


### PR DESCRIPTION
## Summary
- remove deprecated `dialect` option from `server/drizzle.config.ts`

## Testing
- `npm run build` *(fails: Cannot find module and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c4748c4ac832cac7faeb548cfcc5f